### PR TITLE
Patch: training scriptの連続実行に関して

### DIFF
--- a/src/model/train.py
+++ b/src/model/train.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import datetime
 
 import matplotlib.pyplot as plt
 import mlflow
@@ -66,9 +67,13 @@ with mlflow.start_run():
     mlflow.log_metric("rmse", rmse)
     mlflow.log_metric("r2", r2)
 
+    # スクリプト実行時のタイムスタンプを取得する
+    timestamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+    models_folder = "models_" + timestamp
+    
     # Finally save the model to the outputs directory for capture
-    os.makedirs(os.path.join(args.output_dir, "models"), exist_ok=True)
-    mlflow.sklearn.save_model(model, os.path.join(args.output_dir, "models"))
+    os.makedirs(os.path.join(args.output_dir, models_folder), exist_ok=True)
+    mlflow.sklearn.save_model(model, os.path.join(args.output_dir, models_folder))
 
     # Plot actuals vs predictions and save the plot within the run
     plt.figure(figsize=(10, 7))


### PR DESCRIPTION
### 問題点
shell-scriptブランチをレビューする中で、`scripts/training/train.sh`実行時に実行され、`src/model/train.py`が呼び出され、次の行でmlflowモデルが書き出されます。しかし、同じフォルダ名が存在することで再度実行した際に名前が重複しているエラーが発生する問題点があがりました。
```
 mlflow.sklearn.save_model(model, os.path.join(args.output_dir, models_folder))
```

▼ こちらはAzure ML Studioジョブ画面のエラーになります、
```
{
  "code": "ExecutionFailed",
  "category": "UserError",
  "message": {
    "NonCompliant": "Process 'python' exited with code 1 and error message 'Execution failed. Process exited with status code 1. Error: Traceback (most recent call last):\n  File \"train.py\", line 71, in <module>\n    mlflow.sklearn.save_model(model, os.path.join(args.output_dir, \"models\"))\n  File \"/azureml-envs/azureml_f7a06f8caf45372be415861317b88043/lib/python3.8/site-packages/mlflow/sklearn/__init__.py\", line 242, in save_model\n    _validate_and_prepare_target_save_path(path)\n  File \"/azureml-envs/azureml_f7a06f8caf45372be415861317b88043/lib/python3.8/site-packages/mlflow/utils/model_utils.py\", line 135, in _validate_and_prepare_target_save_path\n    raise MlflowException(\nmlflow.exceptions.MlflowException: Path '/mnt/azureml/cr/j/8f463e45f6f74bdebc1cecc8c85c543a/cap/data-capability/wd/output_dir/models' already exists and is not empty\n'. Please check the log file 'user_logs/std_log.txt' for more details."
  },
  "details": [
    {
      "name": "exit_codes",
      "value": {
        "Literal": {
          "Compliant": "1"
        }
      }
    }
  ],
  "error": null,
  "node_info": null
}
```
### 解決策＆変更点
そのため、フォルダ名にtimestampを付けたフォルダを作成し、書き出し先にしているするようにコードを変更しました。

### 確認点

- [ ] `scripts/training/train.sh`を連続実行していただき、ジョブが失敗せずに成功するかどうか
- [ ] 直前で実行したtrain.shとモデルの登録が紐づいているかどうか